### PR TITLE
[QuickFix] Vision Attention using SPDA when platform is out of tree

### DIFF
--- a/vllm/model_executor/models/vision.py
+++ b/vllm/model_executor/models/vision.py
@@ -94,7 +94,7 @@ def get_vit_attn_backend(support_fa: bool = False) -> _Backend:
                     "so we use xformers backend instead. You can run "
                     "`pip install flash-attn` to use flash-attention backend.")
                 selected_backend = _Backend.XFORMERS
-        elif current_platform.is_cpu() or current_platform.is_rocm():
+        elif current_platform.is_cpu() or current_platform.is_rocm() or current_platform.is_out_of_tree():
             # ROCM doesn't support xformers
             selected_backend = _Backend.TORCH_SDPA
         else:


### PR DESCRIPTION
**Title**: Support qwen2-vl on NPU by Using Torch SPDA Instead of Xformers on Out-of-Tree Platforms

**Description**  
This PR adds support for running **qwen2-vl** on NPUs by introducing a new logic in `vision.py`. Specifically, when the platform is detected as out-of-tree, it switches the Attention backend from **xformers** to **Torch SPDA**. The primary goal is to ensure compatibility and performance on NPUs without affecting existing GPU/CPU workflows.

1. **Platform Detection**  
   - Added logic to detect out-of-tree environments.  
   - If the platform is out-of-tree (e.g., certain NPUs), Torch SPDA is used as the backend.  
   - Otherwise, the existing xformers-based backend remains unchanged.

2. **Motivation**  
   - xformers may not work as expected on certain NPU platforms, causing issues for qwen2-vl deployments.  
   - Switching to Torch SPDA on out-of-tree platforms improves compatibility and overall stability.

3. **Impact**  
   - No functional impact on standard GPU/CPU environments.  
   - qwen2-vl can now be compiled, loaded, and executed on NPU platforms with minimal changes.  
   - Wider hardware support enhances the usability and flexibility of the project.
